### PR TITLE
finding git root up in the directory  tree

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -61,6 +61,7 @@
     <Compile Include="GitAliases.cs" />
     <Compile Include="GitAliases.Describe.cs" />
     <Compile Include="GitAliases.Diff.cs" />
+    <Compile Include="GitAliases.GitFindRootFromPath.cs" />
     <Compile Include="GitAliases.Init.cs" />
     <Compile Include="GitAliases.Log.cs" />
     <Compile Include="GitAliases.Pull.cs" />

--- a/src/Cake.Git/GitAliases.GitFindRootFromPath.cs
+++ b/src/Cake.Git/GitAliases.GitFindRootFromPath.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using LibGit2Sharp;
+
+namespace Cake.Git
+{
+    public static partial class GitAliases
+    {
+        /// <summary>
+        /// Finding git root path from subtree.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="path">Path to probe the repository.</param>
+        /// <returns>The path to the repository root.</returns>
+        /// <exception cref="ArgumentNullException">If any of the parameters are null.</exception>
+        /// <exception cref="RepositoryNotFoundException">If git root path not found.</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("FindRootFromPath")]
+        public static DirectoryPath GitFindRootFromPath(this ICakeContext context, DirectoryPath path)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+            
+            if (!context.FileSystem.Exist(path))
+            {
+                throw new RepositoryNotFoundException($"Path '{path}' doesn't exists.");
+            }
+            
+            var fsPath = path;
+            do
+            {
+                if (Repository.IsValid(fsPath.FullPath))
+                    return fsPath;
+                var parentDir = fsPath.Combine("../").Collapse();
+                if (!context.FileSystem.Exist(parentDir))
+                    throw new RepositoryNotFoundException($"Path '{path}' doesn't point at a valid Git repository or workdir.");
+                fsPath = parentDir;
+            }
+            while (true);
+        }
+    }
+}

--- a/test.cake
+++ b/test.cake
@@ -300,6 +300,18 @@ Task("Git-Diff")
     }
 });
 
+Task("Git-Find-Root-From-Path")
+    .IsDependentOn("Git-Modify-Commit")
+    .Does(() =>
+{
+    var deepFolder = testInitalRepo.Combine("test-folder/deep");
+    CreateDirectory(deepFolder);
+    var rootFolder = GitFindRootFromPath(deepFolder);
+    Information("Git root folder found: {0}", rootFolder);
+    if (rootFolder.FullPath != testInitalRepo.FullPath)
+        throw new Exception(string.Format("Wrong git root found (actual: {0}, expected: {1})", rootFolder, testInitalRepo));
+});
+
 Task("Git-Set-Tag")
     .IsDependentOn("Git-Modify-Commit")
     .Does(() =>
@@ -426,6 +438,7 @@ Task("Default-Tests")
     .IsDependentOn("Git-Modify-Diff")
     .IsDependentOn("Git-Clone")
     .IsDependentOn("Git-Diff")
+    .IsDependentOn("Git-Find-Root-From-Path")
     .IsDependentOn("Git-Describe");
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hello!
I'd like to use Cake.Git tool in my build scripts, but I found that all repositoryDirectoryPath parameters must point to root git working directory.
My cake build script placed inside src subdirectory and I need to find git root up the directories tree.
This PR does just that.
Please, consider to approve this PR.

/cc: @devlead