### PR TITLE
Added support for retrieving information about current branch.

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GitAliases.Branch.cs" />
     <Compile Include="GitAliases.Checkout.cs" />
     <Compile Include="Extensions\RepositoryExtensions.cs" />
     <Compile Include="GitAliases.Add.cs" />
@@ -67,6 +68,7 @@
     <Compile Include="GitAliases.Log.cs" />
     <Compile Include="GitAliases.Pull.cs" />
     <Compile Include="GitAliases.Push.cs" />
+    <Compile Include="GitBranch.cs" />
     <Compile Include="GitChangeKind.cs" />
     <Compile Include="GitCommit.cs" />
     <Compile Include="GitDescribeStrategy.cs" />

--- a/src/Cake.Git/GitAliases.Branch.cs
+++ b/src/Cake.Git/GitAliases.Branch.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Git.Extensions;
+
+namespace Cake.Git
+{
+    // ReSharper disable once PublicMembersMustHaveComments
+    public static partial class GitAliases
+    {
+        /// <summary>
+        /// Gets the current branch.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Path to repository.</param>
+        /// <returns></returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Branch")]
+        public static GitBranch GitBranchCurrent(this ICakeContext context, DirectoryPath repositoryDirectoryPath)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            return context.UseRepository(
+                repositoryDirectoryPath,
+                repository => new GitBranch(repository.Head)
+                );
+        }
+    }
+}

--- a/src/Cake.Git/GitBranch.cs
+++ b/src/Cake.Git/GitBranch.cs
@@ -1,0 +1,48 @@
+﻿using LibGit2Sharp;
+
+namespace Cake.Git
+{
+    /// <summary>
+    /// Representation of a Git branch.
+    /// </summary>
+    public sealed class GitBranch
+    {
+        /// <summary>
+        /// Gets the full name of the branch.
+        /// </summary>
+        /// <value>The full name of the branch.</value>
+        public string CanonicalName { get; }
+
+        /// <summary>
+        /// Gets the human-friendly name of the branch.
+        /// </summary>
+        /// <value>The human-friendly name of the branch.</value>
+        public string FriendlyName { get; }
+
+        /// <summary>
+        /// Gets the commit this branch points to.
+        /// </summary>
+        /// <value>The commit this branch points to.</value>
+        public GitCommit Tip { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitBranch"/> class.
+        /// </summary>
+        /// <param name="branch">The branch.</param>
+        public GitBranch(Branch branch)
+        {
+            CanonicalName = branch.CanonicalName;
+            FriendlyName = branch.FriendlyName;
+            Tip = new GitCommit(branch.Tip);
+        }
+
+        /// <summary>
+        /// Generates a string representation of <see cref="GitBranch"/>
+        /// </summary>
+        /// <returns><see cref="GitBranch"/> as string</returns>
+        public override string ToString()
+        {
+            return $"Canonical name: {CanonicalName}, Friendly name: {FriendlyName}, Tip: ({Tip})";
+        }
+    }
+}

--- a/test.cake
+++ b/test.cake
@@ -407,6 +407,13 @@ Task("Git-Describe-Master")
         throw new Exception("Wrong describe");
 });
 
+Task("Git-Current-Branch")
+    .Does(() =>
+{
+    var branch = GitBranchCurrent(testInitalRepo);
+    Information("Current branch: {0}", branch);
+});
+
 Task("Git-Describe")
     .IsDependentOn("Git-Describe-Generic")
     .IsDependentOn("Git-Describe-Tags")
@@ -439,7 +446,8 @@ Task("Default-Tests")
     .IsDependentOn("Git-Clone")
     .IsDependentOn("Git-Diff")
     .IsDependentOn("Git-Find-Root-From-Path")
-    .IsDependentOn("Git-Describe");
+    .IsDependentOn("Git-Describe")
+    .IsDependentOn("Git-Current-Branch");
 
 ///////////////////////////////////////////////////////////////////////////////
 // EXECUTION


### PR DESCRIPTION
Adds a new alias: `GitBranchCurrent` that will retrieve information about the current branch and return a `GitBranch` object.

```csharp
var branch = GitBranchCurrent("./repository");
Information("Canonical name: {0}", branch.CanonicalName);
Information("Friendly name: {0}", branch.FriendlyName);
Information("Tip: {0}", branch.Tip);
```