### PR TITLE
Added Two Reset method Overloads.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -177,7 +177,7 @@ Task("Test")
     .WithCriteria(() => StringComparer.OrdinalIgnoreCase.Equals(configuration, "Release"))
     .Does(() =>
 {
-    CakeExecuteScript("./test.cake");
+    CakeExecuteScript("./test.cake", new CakeSettings{ Arguments = new Dictionary<string, string>{{"target", target == "Default" ? "Default-Tests" : "Local-Tests"}}});
 });
 
 Task("Create-NuGet-Package")
@@ -221,6 +221,9 @@ Task("Publish-MyGet")
 
 
 Task("Default")
+    .IsDependentOn("Create-NuGet-Package");
+
+Task("Local-Tests")
     .IsDependentOn("Create-NuGet-Package");
 
 Task("AppVeyor")

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GitAliases.Reset.cs" />
     <Compile Include="GitAliases.Branch.cs" />
     <Compile Include="GitAliases.Checkout.cs" />
     <Compile Include="Extensions\RepositoryExtensions.cs" />
@@ -75,6 +76,7 @@
     <Compile Include="GitDiffFile.cs" />
     <Compile Include="GitMergeResult.cs" />
     <Compile Include="GitMergeStatus.cs" />
+    <Compile Include="GitResetMode.cs" />
     <Compile Include="GitSignature.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Namespaces.cs" />

--- a/src/Cake.Git/GitAliases.Reset.cs
+++ b/src/Cake.Git/GitAliases.Reset.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Git.Extensions;
+using LibGit2Sharp;
+
+namespace Cake.Git
+{
+    public static partial class GitAliases
+    {
+        /// <summary>
+        /// Sets the current branch head (HEAD) to a specified commit, 
+        /// optionally modifying index and working tree to match.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Path to repository.</param>
+        /// <param name="mode">The effect that the reset action should have on the the index and working tree.</param>
+        /// <param name="commitId">The id of the commit to which the current branch HEAD should be set.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Reset")]
+        public static void GitReset(
+            this ICakeContext context,
+            DirectoryPath repositoryDirectoryPath,
+            GitResetMode mode,
+            string commitId)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            context.UseRepository(repositoryDirectoryPath,
+                repository => repository.Reset((ResetMode) mode, repository.Lookup<Commit>(commitId)));
+        }
+
+        /// <summary>
+        /// Resets the current branch head (HEAD) optionally modifying index and working tree to match.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Path to repository.</param>
+        /// <param name="mode">The effect that the reset action should have on the the index and working tree.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Reset")]
+        public static void GitReset(
+            this ICakeContext context,
+            DirectoryPath repositoryDirectoryPath,
+            GitResetMode mode)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            context.UseRepository(repositoryDirectoryPath,
+                repository => repository.Reset((ResetMode)mode));
+        }
+    }
+}

--- a/src/Cake.Git/GitResetMode.cs
+++ b/src/Cake.Git/GitResetMode.cs
@@ -1,0 +1,27 @@
+﻿using LibGit2Sharp;
+
+namespace Cake.Git
+{
+    /// <summary>
+    /// The mode to be used when resetting the branch head 
+    /// and, optionally, the index and the working tree.
+    /// </summary>
+    public enum GitResetMode
+    {
+        /// <summary>
+        /// Resets the index and working tree. Any changes to tracked 
+        /// files in the working tree since the latest or specified commit are discarded.
+        /// </summary>
+        Hard = ResetMode.Hard,
+        /// <summary>
+        /// Resets the index but not the working tree (i.e., the changed files are 
+        /// preserved but not marked for commit).
+        /// </summary>
+        Soft = ResetMode.Soft,
+        /// <summary>
+        /// Resets the index and working tree. Any changes to tracked files in the 
+        /// working tree since the latest or specified commit are discarded.
+        /// </summary>
+        Mixed = ResetMode.Mixed
+    }
+}


### PR DESCRIPTION
Hi Guys, 
I've forked Cake.Git and added two reset overloads that call into the corresponding libgit2sharp methods. The reason for making this addition is that we want to be able to roll back the updates made by GitVersion to our AssemblyInfo.cs files at the end of a build.

Ideally, we'd like to be able to specify a pattern to target */AssemblyInfo.cs and no other files since there may be build artifacts that we wish to retain (and for which .gitignore is too brittle a protection). However, I see that libgit2sharp doesn't offer calling into the git_reset_default method in libgit2.

**Summary of Additions**

**GitReset(ResetMode)** which resets the current branch HEAD to the latest
commit and, optionally, modifies the index and working tree.

**GitReset(ResetMode, CommitId)** which resets the current branch HEAD to the
specified commit and, optionally, modifies the index and working tree.