### PR TITLE
Add alias for git push with refspec

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -91,12 +91,6 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.157\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.157\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,7 +41,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20150419160303\lib\net40\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20160803182831\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Cake.Git/GitAliases.Checkout.cs
+++ b/src/Cake.Git/GitAliases.Checkout.cs
@@ -60,7 +60,7 @@ namespace Cake.Git
             {
                 context.UseRepository(
                     repositoryDirectoryPath,
-                    repository => repository.Checkout(
+                    repository => Commands.Checkout(repository,
                         committishOrBranchSpec,
                         new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force }
                         )

--- a/src/Cake.Git/GitAliases.Push.cs
+++ b/src/Cake.Git/GitAliases.Push.cs
@@ -167,5 +167,134 @@ namespace Cake.Git
                 }
                 );
         }
+
+        /// <summary>
+        /// Push a tag to a remote unauthenticated.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Repository path.</param>
+        /// <param name="remote">The <see cref="T:LibGit2Sharp.Remote"/> to push to.</param>
+        /// <param name="pushRefSpec">The pushRefSpec to push.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Push")]
+        public static void GitPushRef(
+            this ICakeContext context,
+            DirectoryPath repositoryDirectoryPath,
+            string remote, string pushRefSpec)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            if (remote == null)
+            {
+                throw new ArgumentNullException(nameof(remote));
+            }
+
+            if (string.IsNullOrWhiteSpace(remote))
+            {
+                throw new ArgumentException("Remote cannot be empty", nameof(remote));
+            }
+
+            if (pushRefSpec == null)
+            {
+                throw new ArgumentNullException(nameof(pushRefSpec));
+            }
+
+            if (string.IsNullOrWhiteSpace(pushRefSpec))
+            {
+                throw new ArgumentException("Pushrefspec cannot be empty", nameof(pushRefSpec));
+            }
+
+            context.UseRepository(
+                repositoryDirectoryPath,
+                repository => repository.Network.Push(repository.Network.Remotes[remote],
+                repository.Tags[pushRefSpec].CanonicalName)
+                );
+        }
+
+        /// <summary>
+        /// Push a tag to a remote authenticated.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Repository path.</param>
+        /// <param name="username">Username used for authentication.</param>
+        /// <param name="password">Password used for authentication.</param>
+        /// <param name="remote">The <see cref="T:LibGit2Sharp.Remote"/> to push to.</param>
+        /// <param name="pushRefSpec">The pushRefSpec to push.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Push")]
+        public static void GitPushRef(
+            this ICakeContext context,
+            DirectoryPath repositoryDirectoryPath,
+            string username,
+            string password,
+            string remote, string pushRefSpec)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            if (remote == null)
+            {
+                throw new ArgumentNullException(nameof(remote));
+            }
+
+            if (string.IsNullOrWhiteSpace(remote))
+            {
+                throw new ArgumentException("Remote cannot be empty", nameof(remote));
+            }
+
+            if (pushRefSpec == null)
+            {
+                throw new ArgumentNullException(nameof(pushRefSpec));
+            }
+
+            if (string.IsNullOrWhiteSpace(pushRefSpec))
+            {
+                throw new ArgumentException("Pushrefspec cannot be empty", nameof(pushRefSpec));
+            }
+
+            if (username == null)
+            {
+                throw new ArgumentNullException(nameof(username));
+            }
+
+            if (password == null)
+            {
+                throw new ArgumentNullException(nameof(password));
+            }
+
+            var options = new PushOptions
+            {
+                CredentialsProvider = (url, usernameFromUrl, types) =>
+                    new UsernamePasswordCredentials
+                    {
+                        Username = username,
+                        Password = password
+                    }
+            };
+
+            context.UseRepository(
+                repositoryDirectoryPath,
+                repository => repository.Network.Push(repository.Network.Remotes[remote], 
+                repository.Tags[pushRefSpec].CanonicalName, 
+                options)
+                );
+        }
     }
 }

--- a/src/Cake.Git/packages.config
+++ b/src/Cake.Git/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.15.2" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.23.0-pre20160803182831" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.157" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR adds two aliases for pushing with a refspec which is needed in order to tag a remote.

Usage example:
    GitTag("./", "v1.0.0");
    GitPushRef("./", gitUsername, gitPassword, "origin", "v1.0.0");

[Fixes: https://github.com/WCOMAB/Cake_Git/issues/9]