### PR TITLE
Adds GitRemote to GitBranch

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -77,6 +77,7 @@
     <Compile Include="GitDiffFile.cs" />
     <Compile Include="GitMergeResult.cs" />
     <Compile Include="GitMergeStatus.cs" />
+    <Compile Include="GitRemote.cs" />
     <Compile Include="GitResetMode.cs" />
     <Compile Include="GitSignature.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Cake.Git/GitAliases.Branch.cs
+++ b/src/Cake.Git/GitAliases.Branch.cs
@@ -31,7 +31,7 @@ namespace Cake.Git
 
             return context.UseRepository(
                 repositoryDirectoryPath,
-                repository => new GitBranch(repository.Head)
+                repository => new GitBranch(repository)
                 );
         }
     }

--- a/src/Cake.Git/GitBranch.cs
+++ b/src/Cake.Git/GitBranch.cs
@@ -27,14 +27,34 @@ namespace Cake.Git
         public GitCommit Tip { get; }
 
         /// <summary>
+        /// Gets a value indicating whether this branch is remote.
+        /// </summary>
+        /// <value>The a value indicating whether this branch is remote.</value>
+        public bool IsRemote { get; }
+
+        /// <summary>
+        /// Gets the remote name for this branch.
+        /// </summary>
+        /// <value>The remote name for this branch.</value>
+        public string RemoteName { get; }
+
+        /// <summary>
+        /// Gets or sets the remotes.
+        /// </summary>
+        public System.Collections.Generic.List<GitRemote> Remotes { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GitBranch"/> class.
         /// </summary>
-        /// <param name="branch">The branch.</param>
-        public GitBranch(Branch branch)
+        /// <param name="repository">The repository.</param>
+        public GitBranch(Repository repository)
         {
-            CanonicalName = branch.CanonicalName;
-            FriendlyName = branch.FriendlyName;
-            Tip = new GitCommit(branch.Tip);
+            CanonicalName = repository.Head.CanonicalName;
+            FriendlyName = repository.Head.FriendlyName;
+            Tip = new GitCommit(repository.Head.Tip);
+            IsRemote = repository.Head.IsRemote;
+            RemoteName = repository.Head.RemoteName;
+            Remotes = System.Linq.Enumerable.ToList(System.Linq.Enumerable.Select(repository.Network.Remotes, remote => new GitRemote(remote.Name, remote.PushUrl, remote.Url)));
         }
 
         /// <summary>
@@ -43,7 +63,7 @@ namespace Cake.Git
         /// <returns><see cref="GitBranch"/> as string</returns>
         public override string ToString()
         {
-            return $"Canonical name: {CanonicalName}, Friendly name: {FriendlyName}, Tip: ({Tip})";
+            return $"Canonical name: {CanonicalName}, Friendly name: {FriendlyName}, Tip: ({Tip}), IsRemote: ({IsRemote}), RemoteName: ({RemoteName}), Remotes: [{System.String.Join(", ", Remotes)}]";
         }
     }
 }

--- a/src/Cake.Git/GitRemote.cs
+++ b/src/Cake.Git/GitRemote.cs
@@ -1,0 +1,54 @@
+﻿using LibGit2Sharp;
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace Cake.Git
+{
+    /// <summary>
+    /// Representation of a Git remote.
+    /// </summary>
+    public sealed class GitRemote
+    {
+        /// <summary>
+        /// Gets the Name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the url.
+        /// </summary>
+        public string Url { get; }
+
+        /// <summary>
+        /// Gets the push url.
+        /// </summary>
+        public string PushUrl { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitRemote"/> class.
+        /// </summary>
+        /// <param name="name">
+        /// The remote name.
+        /// </param>
+        /// <param name="pushUrl">
+        /// The push url.
+        /// </param>
+        /// <param name="url">
+        /// The url.
+        /// </param>
+        public GitRemote(string name, string pushUrl, string url)
+        {
+            Name = name;
+            Url = url;
+            PushUrl = pushUrl;
+        }
+
+        /// <summary>
+        /// Generates a string representation of <see cref="GitRemote"/>
+        /// </summary>
+        /// <returns><see cref="GitRemote"/> as string</returns>
+        public override string ToString()
+        {
+            return $"( Name: {Name}, Url: {Url}, PushUrl: {PushUrl} )";
+        }
+    }
+}

--- a/test.cake
+++ b/test.cake
@@ -416,6 +416,13 @@ Task("Git-Current-Branch")
     Information("Current branch: {0}", branch);
 });
 
+Task("Git-Remote-Branch")
+    .Does(() =>
+{
+    var branch = GitBranchCurrent(".");
+    Information("Remote branch: {0}", branch);
+});
+
 Task("Git-Checkout")
     .Does(() =>
 {
@@ -499,6 +506,7 @@ Task("Default-Tests")
     .IsDependentOn("Git-Reset")
     .IsDependentOn("Git-Describe")
     .IsDependentOn("Git-Current-Branch")
+    .IsDependentOn("Git-Remote-Branch")
     .IsDependentOn("Git-Checkout");
 
 Task("Local-Tests")
@@ -520,6 +528,7 @@ Task("Local-Tests")
     .IsDependentOn("Git-Reset")
     .IsDependentOn("Git-Describe")
     .IsDependentOn("Git-Current-Branch")
+    .IsDependentOn("Git-Remote-Branch")
     .IsDependentOn("Git-Checkout");
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is just adding information about remotes.

I went ahead and added it to GitBranch rather than including an additional alias for GitRemote.

The test assumes that you are building from a git repository, not from a zip download.