### PR TITLE
Add GitCloneSettings support

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -72,6 +72,7 @@
     <Compile Include="GitAliases.Tag.cs" />
     <Compile Include="GitBranch.cs" />
     <Compile Include="GitChangeKind.cs" />
+    <Compile Include="GitCloneSettings.cs" />
     <Compile Include="GitCommit.cs" />
     <Compile Include="GitDescribeStrategy.cs" />
     <Compile Include="GitDiffFile.cs" />

--- a/src/Cake.Git/GitAliases.Clone.cs
+++ b/src/Cake.Git/GitAliases.Clone.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.IO;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
 using LibGit2Sharp;
+using System;
+using System.IO;
 
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable UnusedMember.Global
@@ -64,6 +64,63 @@ namespace Cake.Git
         }
 
         /// <summary>
+        /// Clone unauthenticated using default options.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceUrl">URI for the remote repository.</param>
+        /// <param name="workDirectoryPath">Local path to clone into.</param>
+        /// <param name="cloneSettings">The clone settings.</param>
+        /// <returns>
+        /// The path to the created repository.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">If any of the arguments are null.</exception>
+        /// <exception cref="DirectoryNotFoundException">If parent directory doesnt exist.</exception>
+        /// <exception cref="IOException">If workDirectoryPath already exists.</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clone")]
+        public static DirectoryPath GitClone(
+            this ICakeContext context,
+            string sourceUrl,
+            DirectoryPath workDirectoryPath,
+            GitCloneSettings cloneSettings
+            )
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (string.IsNullOrWhiteSpace(sourceUrl))
+            {
+                throw new ArgumentNullException(nameof(sourceUrl));
+            }
+
+            if (workDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(workDirectoryPath));
+            }
+
+            cloneSettings = cloneSettings ?? new GitCloneSettings();
+
+            var workFullDirectoryPath = workDirectoryPath.MakeAbsolute(context.Environment);
+            var parentFullDirectoryPath = workFullDirectoryPath.Combine("../").Collapse();
+
+            if (!context.FileSystem.Exist(parentFullDirectoryPath))
+            {
+                throw new DirectoryNotFoundException($"Failed to find {nameof(parentFullDirectoryPath)}: {parentFullDirectoryPath}");
+            }
+
+            if (context.FileSystem.Exist(workFullDirectoryPath))
+            {
+                throw new IOException($"{nameof(workFullDirectoryPath)} already exists: {workFullDirectoryPath}");
+            }
+
+            context.FileSystem.GetDirectory(workFullDirectoryPath).Create();
+
+            return Repository.Clone(sourceUrl, workFullDirectoryPath.FullPath, cloneSettings.ToCloneOptions());
+        }
+
+        /// <summary>
         /// Clone authenticated using default options.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -119,8 +176,75 @@ namespace Cake.Git
             var options = new CloneOptions
             {
                 CredentialsProvider =
-                    (url, user, cred) => new UsernamePasswordCredentials {Username = username, Password = password}
+                    (url, user, cred) => new UsernamePasswordCredentials { Username = username, Password = password }
             };
+
+            return Repository.Clone(sourceUrl, workFullDirectoryPath.FullPath, options);
+        }
+
+        /// <summary>
+        /// Clone authenticated using default options.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceUrl">URI for the remote repository.</param>
+        /// <param name="workDirectoryPath">Local path to clone into.</param>
+        /// <param name="username">Username used for authentication.</param>
+        /// <param name="password">Password used for authentication.</param>
+        /// <param name="cloneSettings">The clone settings.</param>
+        /// <returns>
+        /// The path to the created repository.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">Failed to find workDirectoryPath: {workFullDirectoryPath}</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clone")]
+        public static DirectoryPath GitClone(
+            this ICakeContext context,
+            string sourceUrl,
+            DirectoryPath workDirectoryPath,
+            string username,
+            string password,
+            GitCloneSettings cloneSettings
+            )
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (string.IsNullOrWhiteSpace(sourceUrl))
+            {
+                throw new ArgumentNullException(nameof(sourceUrl));
+            }
+
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                throw new ArgumentNullException(nameof(username));
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentNullException(nameof(password));
+            }
+
+            if (workDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(workDirectoryPath));
+            }
+
+            cloneSettings = cloneSettings ?? new GitCloneSettings();
+
+            var workFullDirectoryPath = workDirectoryPath.MakeAbsolute(context.Environment);
+
+            if (!context.FileSystem.Exist(workFullDirectoryPath))
+            {
+                throw new DirectoryNotFoundException($"Failed to find workDirectoryPath: {workFullDirectoryPath}");
+            }
+
+            var options = cloneSettings.ToCloneOptions();
+            options.CredentialsProvider =
+                (url, user, cred) => new UsernamePasswordCredentials { Username = username, Password = password };
 
             return Repository.Clone(sourceUrl, workFullDirectoryPath.FullPath, options);
         }

--- a/src/Cake.Git/GitCloneSettings.cs
+++ b/src/Cake.Git/GitCloneSettings.cs
@@ -1,0 +1,43 @@
+﻿using LibGit2Sharp;
+
+namespace Cake.Git
+{
+    /// <summary>
+    /// Contains settings used by GitClone.
+    /// </summary>
+    public class GitCloneSettings
+    {
+        /// <summary>
+        /// True will result in a bare clone, false a full clone.
+        /// </summary>
+        public bool IsBare { get; set; }
+
+        /// <summary>
+        /// If true, the origin's HEAD will be checked out. This only applies
+        /// to non-bare repositories.
+        /// </summary>
+        public bool Checkout { get; set; } = true;
+
+        /// <summary>
+        /// The name of the branch to checkout. When unspecified the
+        /// remote's default branch will be used instead.
+        /// </summary>
+        public string BranchName { get; set; }
+
+        /// <summary>
+        /// Recursively clone submodules.
+        /// </summary>
+        public bool RecurseSubmodules { get; set; }
+
+        internal CloneOptions ToCloneOptions()
+        {
+            return new CloneOptions
+            {
+                IsBare = this.IsBare,
+                Checkout = this.Checkout,
+                BranchName = this.BranchName,
+                RecurseSubmodules = this.RecurseSubmodules
+            };
+        }
+    }
+}

--- a/test.cake
+++ b/test.cake
@@ -283,7 +283,27 @@ Task("Git-Clone")
 {
     var sourceUrl = "https://github.com/WCOMAB/CakeGitTestRepo.git";
     Information("Cloning repo {0}...", sourceUrl);
+    if (DirectoryExists(testCloneRepo))
+    {
+        ForceDeleteDirectory(testCloneRepo.FullPath);
+    }
     var repo = GitClone(sourceUrl, testCloneRepo);
+    Information("Cloned {0}.", repo);
+});
+
+Task("Git-Clone-WithSettings")
+    .IsDependentOn("Clean")
+    .Does(() =>
+{
+    var sourceUrl = "https://github.com/WCOMAB/CakeGitTestRepo.git";
+    Information("Cloning bare repo {0}...", sourceUrl);
+    if (DirectoryExists(testCloneRepo))
+    {
+        ForceDeleteDirectory(testCloneRepo.FullPath);
+    }
+    var repo = GitClone(sourceUrl, testCloneRepo, new GitCloneSettings {
+        IsBare = true
+    });
     Information("Cloned {0}.", repo);
 });
 
@@ -501,6 +521,7 @@ Task("Default-Tests")
     .IsDependentOn("Git-Modify-Commit")
     .IsDependentOn("Git-Modify-Diff")
     .IsDependentOn("Git-Clone")
+    .IsDependentOn("Git-Clone-WithSettings")
     .IsDependentOn("Git-Diff")
     .IsDependentOn("Git-Find-Root-From-Path")
     .IsDependentOn("Git-Reset")


### PR DESCRIPTION
Pardon the noob here. This is my very first pull request. So if I've done anything wrong, just let me know.

I'm new to Cake, but I have need for some build automation scripts that will use Git to do more than the current Cake.Git supports. Hence, this (and future) pull request(s). I've started with a simple one. I need to be able to clone a repo, checking out a specific branch. This is fairly easy to support by following the typical Cake convention of having an overload that takes a Settings object. I've done this for the two existing GitClone methods, and the GitCloneSettings I added supports all of the same features that CloneOptions in LibGit2Sharp gives. I've tried to follow existing practice, though without a contributions document I may have messed something up style wise. I've also attempted to add an integration test for this, though Cake testing is a new concept to me, and I may well have done something there you don't care for.

All in all, though, this is a fairly simple addition, so it should be an easy review.