### PR TITLE
Add GitIsValidRepository alias

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GitAliases.Repository.cs" />
     <Compile Include="GitAliases.Reset.cs" />
     <Compile Include="GitAliases.Branch.cs" />
     <Compile Include="GitAliases.Checkout.cs" />

--- a/src/Cake.Git/GitAliases.Repository.cs
+++ b/src/Cake.Git/GitAliases.Repository.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using LibGit2Sharp;
+// ReSharper disable UnusedMember.Global
+
+namespace Cake.Git
+{
+    public static partial class GitAliases
+    {
+        /// <summary>
+        /// Checks if a specific directory is a valid Git repository.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///     var result = GitIsValidRepository("c:/temp/cake");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="path">Path to the repository to check.</param>
+        /// <returns>True if the path is part of a valid Git Repository.</returns>
+        /// <exception cref="ArgumentNullException">If any of the parameters are null.</exception>
+        /// <exception cref="RepositoryNotFoundException">If path doesn't exist.</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Repository")]
+        public static bool GitIsValidRepository(this ICakeContext context, DirectoryPath path)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (!context.FileSystem.Exist(path))
+            {
+                throw new RepositoryNotFoundException($"Path '{path}' doesn't exists.");
+            }
+
+            return Repository.IsValid(path.FullPath);
+        }
+    }
+}

--- a/test.cake
+++ b/test.cake
@@ -104,6 +104,28 @@ Task("Git-Init")
     Information("Repository created {0}.", repo);
 });
 
+Task("Git-IsValidRepository-LocalRepo")
+    .IsDependentOn("Git-Init")
+    .Does(() =>
+{
+    Information("Checking if local repository is recognized as a valid repository...");
+    if (!GitIsValidRepository(testInitalRepo)) {
+        throw new Exception(string.Format("Initialized repository at '{0}' is not a valid Git repository.",
+            testInitalRepo));
+    }
+});
+
+Task("Git-IsValidRepository-TempDirectory")
+    .Does(() =>
+{
+    Information("Checking if temp directory is not reported as a valid repository...");
+    var tempPath = System.IO.Path.GetTempPath();
+    if (GitIsValidRepository(tempPath)) {
+        throw new Exception(string.Format("Path at '{0}' should not be a valid Git repository.",
+            tempPath));
+    }
+});
+
 Task("Create-Test-Files")
     .IsDependentOn("Git-Init")
     .Does(() =>
@@ -528,8 +550,14 @@ Task("Git-Reset")
     .IsDependentOn("Git-Reset-Stage-File")
     .IsDependentOn("Git-Reset-Hard");
 
+Task("Git-IsValidRepository")
+    .IsDependentOn("Git-IsValidRepository-LocalRepo")
+    .IsDependentOn("Git-IsValidRepository-TempDirectory");
+
 Task("Default-Tests")
     .IsDependentOn("Git-Init")
+    .IsDependentOn("Git-IsValidRepository-LocalRepo")
+    .IsDependentOn("Git-IsValidRepository-TempDirectory")
     .IsDependentOn("Create-Test-Files")
     .IsDependentOn("Git-Init-Add")
     .IsDependentOn("Git-Init-Commit")
@@ -555,6 +583,8 @@ Task("Default-Tests")
 
 Task("Local-Tests")
     .IsDependentOn("Git-Init")
+    .IsDependentOn("Git-IsValidRepository-LocalRepo")
+    .IsDependentOn("Git-IsValidRepository-TempDirectory")
     .IsDependentOn("Create-Test-Files")
     .IsDependentOn("Git-Init-Add")
     .IsDependentOn("Git-Init-Commit")


### PR DESCRIPTION
Add new alias for checking if a path contains a valid Git repository.

I used a new category `Repository` for this. Maybe the `GitFindRootFromPath` alias later can also be changed to use the `Repository` category.